### PR TITLE
Added handling for updated jito API

### DIFF
--- a/superstake-ui/src/hooks/useJitoSolMetrics.ts
+++ b/superstake-ui/src/hooks/useJitoSolMetrics.ts
@@ -25,16 +25,12 @@ function useJitoSolMetrics(pollingRateMs = DEFAULT_METRICS_POLLING_RATE_MS) {
 			const data = await fetchJitoSolMetrics();
 
 			const past30DaysApyAvg =
-				(data.data.getStakePoolStats.apy
-					.slice(-30)
-					.reduce((a, b) => a + b.data, 0) /
-					30) *
-				100;
+				(data.apy.slice(-30).reduce((a, b) => a + b.data, 0) / 30) * 100;
 
 			const priceInSol =
-				data.data.getStakePoolStats.tvl.slice(-1)[0].data /
+				data.tvl.slice(-1)[0].data /
 				JITO_SOL.spotMarket.precision.toNumber() /
-				data.data.getStakePoolStats.supply.slice(-1)[0].data;
+				data.supply.slice(-1)[0].data;
 
 			setMetrics({
 				loaded: true,


### PR DESCRIPTION
This is an alternate PR to the other one which is open ... I think the other one is better because it creates more standardised code and the numbers more closely match solana compass (because they also use this source) BUTTTT I'm blocked on feeling confident with that PR because I'm struggling to emulate other accounts to test with .... so this is just the smallest number of changes required to avoid things breaking when they deprecate the old API.